### PR TITLE
Add AppVeyor build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # whoami for Windows
+[![Build status](https://ci.appveyor.com/api/projects/status/bhma7tmx0eje73ao/branch/master?svg=true)](https://ci.appveyor.com/project/StefanScherer/whoami/branch/master)
 
 Simple HTTP docker service that prints it's container ID
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+version: 1.0.{build}
+environment:
+  DOCKER_USER:
+    secure: LjNiW/ZWrfVIJn3Mc9foeg==
+  DOCKER_PASS:
+    secure: DWlZYy4BAD1B2oovKAqeUQc8N1fNtr78Yd/hwX6AwQrqCHnyC+Tt/SjjzeWEje0P
+install:
+  - choco install -y docker -pre
+  - choco install -y curl
+  - curl.exe -s http://whatismijnip.nl
+  - docker version
+
+build_script:
+  - ps: .\build.ps1
+
+deploy_script:
+  - ps: .\deploy.ps1
+
+test: off

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,21 @@
+$ErrorActionPreference = 'Stop';
+$files = ""
+Write-Host Starting build
+
+Write-Host Updating base images
+docker pull microsoft/windowsservercore
+docker pull microsoft/nanoserver
+
+Write-Host Removing old images
+$ErrorActionPreference = 'SilentlyContinue';
+docker rmi $(docker images --no-trunc --format '{{.Repository}}:{{.Tag}}' | sls -notmatch -pattern '(REPOSITORY|microsoft\/(windowsservercore|nanoserver))')
+$ErrorActionPreference = 'Stop';
+Write-Host Prune system
+docker system prune -f
+
+docker build -t httpbuild -f Dockerfile.build .
+docker create --name httpbuild httpbuild
+docker cp httpbuild:/code/http.exe tmp
+docker build -t whoami .
+
+docker images

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -1,0 +1,14 @@
+$ErrorActionPreference = 'Stop';
+
+if (! (Test-Path Env:\APPVEYOR_REPO_TAG_NAME)) {
+  Write-Host "No version tag detected. Skip publishing."
+  exit 0
+}
+
+Write-Host Starting deploy
+docker login -u="$env:DOCKER_USER" -p="$env:DOCKER_PASS"
+
+docker tag whoami stefanscherer/whoami-windows:$env:APPVEYOR_REPO_TAG_NAME
+docker tag whoami stefanscherer/whoami-windows:latest
+docker push stefanscherer/whoami-windows:$env:APPVEYOR_REPO_TAG_NAME
+docker push stefanscherer/whoami-windows:latest


### PR DESCRIPTION
Use AppVeyor to build the Go binary as well as the Windows Docker image.
Push the Docker image for tagged builds.
