### PR TITLE
Try Circle CI 2.0 to build ARM Docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - checkout
       - run: docker version
       # get latest CE version
-      - run: curl -fsSL https://raw.githubusercontent.com/StefanScherer/docker-init/master/ubuntu/install-docker-ce.sh | sh
+      - run: curl https://get.docker.com | sh
       - run: docker version
       - run: ARCH=arm ./travis-build.sh
       - run: ARCH=arm ./travis-test.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,5 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: docker version
-      # get latest CE version
-      - run: curl https://get.docker.com | sh
-      - run: docker version
       - run: ARCH=arm ./travis-build.sh
       - run: ARCH=arm ./travis-test.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/whoami
+    machine: true
+    steps:
+      - checkout
+      - run: docker version
+      # get latest CE version
+      - run: curl -fsSL https://raw.githubusercontent.com/StefanScherer/docker-init/master/ubuntu/install-docker-ce.sh | sh
+      - run: docker version
+      - run: ARCH=arm ./travis-build.sh
+      - run: ARCH=arm ./travis-test.sh


### PR DESCRIPTION
As Circle CI 2.0 gives you a full VM with an  #upstream Docker engine it is now possible to build ARM Docker images in Circle CI as well.
Here is an example config that builds and runs an ARM Docker image with the same steps used as in Travis CI.

```yaml
version: 2
jobs:
  build:
    working_directory: ~/whoami
    machine: true
    steps:
      - checkout
      - run: curl https://get.docker.com | sh
      - run: docker run --rm --privileged multiarch/qemu-user-static:register --reset
      - run: docker build -t whoami -f "Dockerfile.arm" .
      - run: docker run -d -p 8080:8080 --name=whoamitest whoami
```

The build scripts first updates to Docker CE 17.06 to have multi-stage builds. And it registers the QEMU binary to build and run Docker images for other CPU architectures.
