### PR TITLE
Remove docker update

### DIFF
--- a/travis-build.sh
+++ b/travis-build.sh
@@ -2,11 +2,6 @@
 set -e
 
 docker version
-uname -a
-echo "Updating Docker engine to have multi-stage builds"
-sudo service docker stop
-curl -fsSL https://get.docker.com/ | sudo sh
-docker version
 
 if [ -d tmp ]; then
   docker rm build


### PR DESCRIPTION
TravisCI has Docker 17.09.0-ce preinstalled. So there is no need to update Docker engine manually during build to have multi-stage build support. 🎉